### PR TITLE
Reimplement gap buffer with a RingBuf.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This library implements a gapbuffer, a dynamic array in which the unused portion of the array is shifted on insertion & removal. This optimizes for insertions and removals which could occur at any point in the file but tend to occur in localized clusters.
 
-It currently implements a subset of the methods and traits of a Vec. Eventually, it will hopefully implement all non-deprecated methods and traits of Vec (or similar equivalents, as the case may be) except for push and pop; mutating of the gapbuffer is only provided through the insert and remove methods because of the ambiguity of push & pop when the uninitialized portion of the buffer can shift around.
+It is currently implemented with a backing RingBuf.


### PR DESCRIPTION
This should resolve memory leaks, and removes all instances of unsafe.

The biggest substantive changes are removal of the slice iterator, changing the iterator implementation to return &T instead of T (necessary to avoid depending on Clone), and removal of the DoubleEndedIterator implementation (mostly because it would require keeping an extra length around if we wanted to do it, and iota isn't using it).

Many of these implementations could probably be more efficient, but as a first pass I think they should work (the tests succeeded the first time after I compiled).
