### PR TITLE
Implement DoubleEndedIterator for Items

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,6 +318,17 @@ impl<'a, T> Iterator for Items<'a, T> {
     }
 }
 
+impl<'a, T> DoubleEndedIterator for Items<'a, T> {
+    #[inline]
+    fn next_back(&mut self) -> Option<&'a T> {
+        let next = self.buff.get((self.buff.len()-1) - self.idx);
+        if next.is_some() {
+            self.idx += 1;
+        }
+        next
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -360,6 +371,27 @@ mod tests {
 
         let mut iterator = test.iter();
         let mut index = range(0,100);
+        loop {
+            match (iterator.next(), index.next()) {
+                (Some(&x), Some(y)) => {
+                    assert!(x == y, "Element at index {} is {}", y, x);
+                }
+                (None, _) | (_, None) => { break }
+            }
+        }
+    }
+
+    #[test]
+    fn test_iter_rev() {
+    //Test reverse iteration.
+        let mut test: GapBuffer<usize> = GapBuffer::new();
+
+        for x in range(0, 100) {
+            test.insert(x,x);
+        }
+
+        let mut iterator = test.iter().rev();
+        let mut index = range(0,100).rev();
         loop {
             match (iterator.next(), index.next()) {
                 (Some(&x), Some(y)) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,8 @@ impl<T> GapBuffer<T> {
     pub fn iter(&self) -> Items<T> {
         Items {
             buff: self,
-            idx: 0,
+            idx_front: 0,
+            idx_back: self.len()-1,
         }
     }
 
@@ -296,7 +297,8 @@ impl<T> IndexMut<usize> for GapBuffer<T> {
 #[derive(Clone)]
 pub struct Items<'a, T: 'a> {
     buff: &'a GapBuffer<T>,
-    idx: usize,
+    idx_front: usize,
+    idx_back: usize,
 }
 
 impl<'a, T> Iterator for Items<'a, T> {
@@ -304,9 +306,9 @@ impl<'a, T> Iterator for Items<'a, T> {
 
     #[inline]
     fn next(&mut self) -> Option<&'a T> {
-        let next = self.buff.get(self.idx);
+        let next = self.buff.get(self.idx_front);
         if next.is_some() {
-            self.idx += 1;
+            self.idx_front += 1;
         }
         next
     }
@@ -321,9 +323,9 @@ impl<'a, T> Iterator for Items<'a, T> {
 impl<'a, T> DoubleEndedIterator for Items<'a, T> {
     #[inline]
     fn next_back(&mut self) -> Option<&'a T> {
-        let next = self.buff.get((self.buff.len()-1) - self.idx);
+        let next = self.buff.get(self.idx_back);
         if next.is_some() {
-            self.idx += 1;
+            self.idx_back -= 1;
         }
         next
     }


### PR DESCRIPTION
This makes `Items` also implement `DoubleEndedIterator`, allowing traversal backwards from the end of the buffer.

Specifically, `gapbuffer.iter().rev()` should now work as expected.
